### PR TITLE
Fix wrong branch in actions

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -3,7 +3,7 @@ name: Build and push
 on:
   pull_request:
     types: [closed]
-    branches: master
+    branches: cpu
     
 jobs:
 


### PR DESCRIPTION
Due to incorrect branch name in action, CPU image was never pushed to dockerhub.